### PR TITLE
Fix running in docker error and update spring-data in pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Couchbase Spring Data Couchbase Travel-Sample Application
 
-NOTE: This requires Spring Data Couchbase with Collection Support which is currently available
-only in the branch datacouch_963_scopes_and_collections_for_repositories. The sample will only
-work if that is cloned and installed locally. 
-
 This is a sample application for getting started with [Couchbase Server] and [Spring Data Couchbase].
 The application runs a single page web UI for demonstrating SQL for Documents (N1QL), Sub-document requests and Full Text Search (FTS) querying capabilities.
 It uses Couchbase Server together with the [Spring Boot] web framework for [Java], [Swagger] for API documentation, [Vue] and [Bootstrap].
@@ -171,9 +167,6 @@ Please ensure that you have the following before proceeding.
 Install the dependencies:
 
     mvn clean install
-
-Note that `spring-boot-devtools` is installed as a dependency, so you can run the server with
-the benefit of automatic restarting as you make changes.
 
 The first time you run against a new database image, you may want to use the provided
 `wait-for-couchbase.sh` wrapper to ensure that all indexes are created.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - db
     ports:
       - 8080:8080
-    volumes:
-      - .:/app
     container_name: try-cb-api
   
   frontend:
@@ -21,11 +19,11 @@ services:
       entrypoint: ["wait-for-it", "backend:8080", "--timeout=400", "--strict", "--", "npm", "run", "serve"]
 
   db:
-    image: couchbase/server-sandbox:7.0.0-beta
+    image: couchbase/server-sandbox:7.0.0
     ports:
       - "8091-8095:8091-8095"
       - "11210:11210"
     expose: # expose ports 8091 & 8094 to other containers (mainly for backend)
       - "8091"
       - "8094"
-    container_name: couchbase-sandbox-7.0.0-beta
+    container_name: couchbase-sandbox-7.0.0

--- a/mix-and-match.yml
+++ b/mix-and-match.yml
@@ -10,8 +10,6 @@ services:
       - CB_USER
       - CB_PSWD
     command: --storage.host=${CB_HOST} --storage.username=${CB_USER} --storage.password=${CB_PSWD}
-    volumes:
-      - .:/app
     container_name: try-cb-api-mm
 
   frontend:
@@ -21,7 +19,7 @@ services:
     container_name: try-cb-fe-mm
 
   db:
-    image: couchbase/server-sandbox:7.0.0-beta
+    image: couchbase/server-sandbox:7.0.0
     ports:
       - "8091-8095:8091-8095"
       - "9102:9102"
@@ -29,4 +27,4 @@ services:
     expose:
       - "8091"
       - "8094"
-    container_name: couchbase-sandbox-7.0.0-beta-mm
+    container_name: couchbase-sandbox-7.0.0-mm

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-couchbase</artifactId>
-            <version>4.3.0-SNAPSHOT</version>
+            <version>4.3.0-M2</version>
         </dependency>
         <!-- Gson to json-stringify objects -->
         <dependency>
@@ -84,13 +84,6 @@
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.5.9</version>
         </dependency>
-
-        <!-- spring-boot dev tools to enable hot-reloading -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <!-- for couchbase prereleases, use the couchbase repo -->
@@ -99,6 +92,11 @@
             <id>couchbase</id>
             <name>Couchbase Preview Repository</name>
             <url>http://files.couchbase.com/maven2</url>
+        </repository>
+        <repository>
+            <id>spring-libs-milestone</id>
+            <name>Spring Milestone Repository</name>
+            <url>https://repo.spring.io/libs-milestone</url>
         </repository>
     </repositories>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 jwt.secret=UNSECURE_SECRET_TOKEN
 jwt.enabled=true
-storage.host=10.144.210.101
+storage.host=db
 storage.bucket=travel-sample
 storage.username=Administrator
 storage.password=password


### PR DESCRIPTION
* Fixes issue with starting up the backend with `docker-compose up` (default couchbase host was not set to `db` in the `application.properties` file)
* Removes the need for volumes in the docker-compose files. This was initially there for hot-reloading but I'm removing it as it's not necessary/adds complexity. Doesn't quite work that well anyway.
* Updates the couchbase sandbox image to 7.0.0
* Updates spring-data to the latest released version `4.3.0-M2`, no need to build a separate snapshot now.